### PR TITLE
feat: add /design command to dev-team example

### DIFF
--- a/examples/dev-team/.claude/commands/design.md
+++ b/examples/dev-team/.claude/commands/design.md
@@ -1,0 +1,134 @@
+---
+description: Create design documents for features or projects
+---
+
+# Design Doc Skill
+
+Create and manage design documents (RFCs) for complex features or new projects. Design docs are created before implementation to align on approach, identify risks, and serve as handoff artifacts.
+
+## Usage
+
+```
+/design                    # Create a new design doc (interactive)
+/design {issue}            # Create design doc from a GitHub issue
+/design list               # List all design docs for current project
+/design review {doc}       # Review an existing design doc
+```
+
+## Process
+
+### `/design` or `/design {issue}`
+
+1. **Determine project context:**
+   - Detect project from current working directory or git remote
+   - Load project memory from `memory/projects/{project}/`
+   - If no project memory exists, suggest running `/project-init` first
+
+2. **Gather design inputs:**
+   - If `{issue}` provided: fetch issue from GitHub, extract requirements
+   - If no issue: ask user for feature name, problem statement, and scope
+
+3. **Create the design doc:**
+   - Use the template from `memory/templates/design-doc-template.md`
+   - Fill in project context, component architecture, data model
+   - Include alternatives considered
+   - Define implementation phases
+   - Write testing strategy and security considerations
+
+4. **Store the doc:**
+   - Save to `memory/projects/{project}/designs/{issue}-{slug}.md`
+   - If no issue number, use date-based prefix: `{YYYY-MM-DD}-{slug}.md`
+
+5. **Present for review:**
+   - Show summary to user
+   - Highlight open questions
+   - Ask for approval or revision
+
+### `/design list`
+
+1. Detect current project
+2. List all files in `memory/projects/{project}/designs/`
+3. Show each doc's title, status, date, and related issue
+
+### `/design review {doc}`
+
+1. Read the specified design doc
+2. Evaluate against the quality bar:
+   - Problem clearly stated?
+   - Non-goals defined?
+   - Alternatives considered?
+   - TypeScript interfaces for key types?
+   - Testing strategy concrete?
+   - Accessibility section complete? (for UI features)
+   - UX friction points addressed? (forms, navigation, keyboard)
+   - Open questions identified?
+3. Provide feedback and suggestions
+
+## Template
+
+The design doc template lives at `memory/templates/design-doc-template.md`. Key sections:
+
+- **Problem Statement** — What problem, who has it, why it matters
+- **Goals / Non-Goals** — Explicit boundaries
+- **Proposed Solution** — Architecture, data model, API changes, UI design
+- **Alternatives Considered** — At least one rejected approach with rationale
+- **Implementation Phases** — Ordered tasks
+- **Testing Strategy** — Unit, integration, e2e, accessibility
+- **Security Considerations** — Auth, validation, data sensitivity
+- **Open Questions** — Honest unknowns
+- **Handoff Checklist** — Readiness criteria for implementation
+
+## Integration with Workflow
+
+- **Architect agent** creates design docs as part of the `feature` pipeline
+- Design docs become **handoff artifacts** to the senior agent
+- Senior reads the design doc before starting implementation
+- Doc status updated to "Implemented" when work is complete
+- `/team {issue}` can trigger design doc creation when architect is in the composition
+
+## Quality Bar
+
+A good design doc:
+- States the problem in 2-3 sentences
+- Lists explicit non-goals
+- Describes at least one rejected alternative
+- Includes key type/interface signatures (NOT implementation code)
+- Has concrete testing strategy (not "we'll add tests")
+- Identifies open questions honestly
+- Can be understood by someone unfamiliar with the codebase
+- **For UI features:** includes a complete Accessibility section covering:
+  - Keyboard navigation plan
+  - Screen reader considerations (ARIA labels, live regions)
+  - Color contrast requirements
+  - Focus management (after modals, form submits, navigation)
+  - Required field indication strategy
+  - Error announcement to assistive technology
+- **For UI features:** addresses UX friction:
+  - Form field count and auto-fill opportunities
+  - Smart defaults (dates, selectors, pre-populated fields)
+  - Navigation hierarchy (breadcrumbs, back links, sidebar state)
+
+## Code in Design Docs — The Rule
+
+**Design docs should NOT contain implementation code.**
+
+Reference: [Stan Design Docs](https://github.com/stan-dev/design-docs) — "The technical specification needs to be specific enough that it can be approved as a plan for implementation. These documents should not include every last detail of an implementation — for example, rarely will code other than function or class signatures be appropriate in either a functional or technical specification."
+
+**What belongs in a design doc:**
+- Function/class/interface **signatures** (inputs, outputs, types)
+- File structure diagrams
+- Component interaction diagrams (UML, ASCII, or Mermaid)
+- Data flow descriptions (text + diagrams)
+- Decision tables and trade-off matrices
+- Pseudocode ONLY when the algorithm itself is the design decision
+
+**What does NOT belong:**
+- Full function bodies or component implementations
+- Configuration objects or config file contents
+- Import statements
+- Hook usage patterns or state management wiring
+- CSS/Tailwind class strings
+- API client implementations
+- Complete middleware or route handler code
+
+The implementer should be able to read the design doc and know WHAT to build and WHY, then make their own implementation decisions for HOW. If the design doc contains copy-pasteable code, it's doing the implementer's job and will become stale immediately.

--- a/examples/dev-team/.claude/commands/design.md
+++ b/examples/dev-team/.claude/commands/design.md
@@ -23,7 +23,7 @@ Create and manage design documents (RFCs) for complex features or new projects. 
 1. **Determine project context:**
    - Detect project from current working directory or git remote
    - Load project memory from `memory/projects/{project}/`
-   - If no project memory exists, suggest running `/project-init` first
+   - If no project memory exists, initialize a new project directory under `memory/projects/{project}/` (including a `designs/` subdirectory) before proceeding
 
 2. **Gather design inputs:**
    - If `{issue}` provided: fetch issue from GitHub, extract requirements

--- a/examples/dev-team/.claude/commands/design.md
+++ b/examples/dev-team/.claude/commands/design.md
@@ -1,4 +1,5 @@
 ---
+name: design
 description: Create design documents for features or projects
 ---
 

--- a/examples/dev-team/.claude/commands/design.md
+++ b/examples/dev-team/.claude/commands/design.md
@@ -22,22 +22,22 @@ Create and manage design documents (RFCs) for complex features or new projects. 
 
 1. **Determine project context:**
    - Detect project from current working directory or git remote
-   - Load project memory from `memory/projects/{project}/`
-   - If no project memory exists, initialize a new project directory under `memory/projects/{project}/` (including a `designs/` subdirectory) before proceeding
+   - Load project memory from `.claude/memory/projects/{project}/`
+   - If no project memory exists, initialize a new project directory under `.claude/memory/projects/{project}/` (including a `designs/` subdirectory) before proceeding
 
 2. **Gather design inputs:**
    - If `{issue}` provided: fetch issue from GitHub, extract requirements
    - If no issue: ask user for feature name, problem statement, and scope
 
 3. **Create the design doc:**
-   - Use the template from `memory/templates/design-doc-template.md`
+   - Use the template from `.claude/memory/templates/design-doc-template.md`
    - Fill in project context, component architecture, data model
    - Include alternatives considered
    - Define implementation phases
    - Write testing strategy and security considerations
 
 4. **Store the doc:**
-   - Save to `memory/projects/{project}/designs/{issue}-{slug}.md`
+   - Save to `.claude/memory/projects/{project}/designs/{issue}-{slug}.md`
    - If no issue number, use date-based prefix: `{YYYY-MM-DD}-{slug}.md`
 
 5. **Present for review:**
@@ -48,7 +48,7 @@ Create and manage design documents (RFCs) for complex features or new projects. 
 ### `/design list`
 
 1. Detect current project
-2. List all files in `memory/projects/{project}/designs/`
+2. List all files in `.claude/memory/projects/{project}/designs/`
 3. Show each doc's title, status, date, and related issue
 
 ### `/design review {doc}`
@@ -67,7 +67,7 @@ Create and manage design documents (RFCs) for complex features or new projects. 
 
 ## Template
 
-The design doc template lives at `memory/templates/design-doc-template.md`. Key sections:
+The design doc template lives at `.claude/memory/templates/design-doc-template.md`. Key sections:
 
 - **Problem Statement** — What problem, who has it, why it matters
 - **Goals / Non-Goals** — Explicit boundaries

--- a/examples/dev-team/.claude/memory/templates/design-doc-template.md
+++ b/examples/dev-team/.claude/memory/templates/design-doc-template.md
@@ -8,7 +8,7 @@ Use this template when creating design documents for complex features or new pro
 
 ## Template
 
-```markdown
+````markdown
 # {Feature Name} Design Document
 
 **Component:** {Component or subsystem name}
@@ -141,7 +141,7 @@ ExampleEntity {
 **Design Sign-off:** {author}
 **Date:** {YYYY-MM-DD}
 **Status:** {Ready for implementation | Needs revision}
-```
+````
 
 ---
 

--- a/examples/dev-team/.claude/memory/templates/design-doc-template.md
+++ b/examples/dev-team/.claude/memory/templates/design-doc-template.md
@@ -1,6 +1,6 @@
 # Design Doc Template
 
-Use this template when creating design documents for complex features or new projects. Design docs are created by the architect agent and serve as handoff artifacts to the senior agent.
+Use this template when creating design documents for complex features or new projects. Design docs are typically drafted by the senior agent (acting as the architect) and serve as handoff artifacts to the review agent.
 
 **Storage:** `.claude/memory/projects/{project}/designs/{issue}-{slug}.md`
 

--- a/examples/dev-team/.claude/memory/templates/design-doc-template.md
+++ b/examples/dev-team/.claude/memory/templates/design-doc-template.md
@@ -1,0 +1,186 @@
+# Design Doc Template
+
+Use this template when creating design documents for complex features or new projects. Design docs are created by the architect agent and serve as handoff artifacts to the senior agent.
+
+**Storage:** `memory/projects/{project}/designs/{issue}-{slug}.md`
+
+---
+
+## Template
+
+```markdown
+# {Feature Name} Design Document
+
+**Component:** {Component or subsystem name}
+**Created:** {YYYY-MM-DD}
+**Author:** {agent or person}
+**Status:** Draft | In Review | Approved | Implemented
+**Target Project:** {project-name}
+**Related Issue:** #{issue_number}
+
+---
+
+## Problem Statement
+
+{What problem does this solve? Who has this problem? Why does it matter?}
+
+## Goals
+
+- {Goal 1}
+- {Goal 2}
+
+## Non-Goals
+
+- {What this does NOT aim to solve}
+- {Explicit boundaries}
+
+## Proposed Solution
+
+### Overview
+
+{High-level description of the approach}
+
+### Component Architecture
+
+{File structure, component hierarchy, data flow}
+
+### Data Model
+
+{Database schema changes, key entity relationships, new types}
+
+Include **type signatures only** — no implementation code:
+
+```
+ExampleEntity {
+  id: string
+  name: string
+  status: 'active' | 'archived'
+  createdAt: DateTime
+  relations: belongs to ParentEntity, has many ChildEntity
+}
+```
+
+### API Changes
+
+{New routes, modified endpoints, request/response shapes — signatures only}
+
+### UI Design
+
+{For UI features: layout, states, responsive behavior}
+
+### Accessibility
+
+{For UI features — required for all user-facing changes}
+
+- **Keyboard navigation:** {How will users navigate this feature without a mouse?}
+- **Screen reader:** {What ARIA labels, live regions, or semantic HTML are needed?}
+- **Color contrast:** {Any custom colors that need contrast verification?}
+- **Focus management:** {Where does focus go after modal open/close, form submit, navigation?}
+- **Required fields:** {Which fields are required? How are they indicated?}
+- **Error handling:** {How are errors announced to assistive technology?}
+- **Responsive:** {How does this work at mobile breakpoints? Touch target sizes?}
+
+## Alternatives Considered
+
+### {Alternative 1}
+
+{Description, why it was rejected}
+
+### {Alternative 2}
+
+{Description, why it was rejected}
+
+## Implementation Phases
+
+### Phase 1 — {Name}
+- {Task 1}
+- {Task 2}
+
+### Phase 2 — {Name}
+- {Task 1}
+- {Task 2}
+
+## Testing Strategy
+
+- **Unit tests:** {What to test, key scenarios}
+- **Integration tests:** {API route tests, database interactions}
+- **E2e tests:** {User flows to cover with Playwright}
+- **Accessibility tests:** {Keyboard navigation paths, screen reader flows, axe-core checks}
+
+## Security Considerations
+
+- {Auth requirements}
+- {Input validation}
+- {Data sensitivity}
+
+## Performance Considerations
+
+- {Expected load}
+- {Optimization strategies}
+- {Caching approach}
+
+## Open Questions
+
+1. {Question — include proposed answer if you have one}
+2. {Question}
+
+## Handoff Checklist
+
+- [ ] Design reviewed and approved
+- [ ] Data model finalized
+- [ ] API contracts defined
+- [ ] Accessibility section complete (keyboard nav, screen reader, contrast, focus management)
+- [ ] UX friction addressed (autoFocus, required indicators, smart defaults, navigation)
+- [ ] Testing strategy clear (including a11y test plan)
+- [ ] Implementation phases ordered
+- [ ] Open questions resolved
+
+---
+
+**Ready for:** `@senior` (Implementation)
+**Design Sign-off:** {author}
+**Date:** {YYYY-MM-DD}
+**Status:** {Ready for implementation | Needs revision}
+```
+
+---
+
+## Guidelines
+
+### When to Create a Design Doc
+
+- New feature with 3+ components or files
+- Database schema changes
+- New API endpoints
+- Architectural decisions with trade-offs
+- Cross-cutting changes affecting multiple subsystems
+- Any work that would benefit from upfront design review
+
+### When NOT to Create a Design Doc
+
+- Bug fixes (just fix it)
+- Simple CRUD additions
+- Styling changes
+- Configuration changes
+- Single-file changes with obvious implementation
+
+### Quality Bar
+
+A good design doc:
+- States the problem clearly in 2-3 sentences
+- Lists explicit non-goals (what you're NOT doing)
+- Describes at least one rejected alternative
+- Includes key type/interface **signatures** (not implementation code)
+- Has a concrete testing strategy
+- Identifies open questions honestly
+- Can be understood by someone unfamiliar with the codebase
+- For UI features: has a complete Accessibility section and addresses UX friction
+- **Contains NO implementation code** — only signatures, diagrams, and pseudocode where the algorithm IS the decision (see [Stan Design Docs](https://github.com/stan-dev/design-docs) philosophy)
+
+### Integration with Workflow
+
+1. Architect agent creates the design doc
+2. Design doc is stored in `memory/projects/{project}/designs/`
+3. Doc becomes a handoff artifact — senior reads it before implementing
+4. Implementation can reference the doc for context
+5. Doc is updated to "Implemented" when work is complete

--- a/examples/dev-team/.claude/memory/templates/design-doc-template.md
+++ b/examples/dev-team/.claude/memory/templates/design-doc-template.md
@@ -2,7 +2,7 @@
 
 Use this template when creating design documents for complex features or new projects. Design docs are created by the architect agent and serve as handoff artifacts to the senior agent.
 
-**Storage:** `memory/projects/{project}/designs/{issue}-{slug}.md`
+**Storage:** `.claude/memory/projects/{project}/designs/{issue}-{slug}.md`
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `/design` slash command for creating, listing, and reviewing design documents (RFCs)
- Add design doc template with structured sections (problem, goals, architecture, alternatives, testing, accessibility, handoff checklist)
- Follows the Stan Design Docs philosophy: signatures and decisions, not implementation code

## Context
Ported from the dev-team-v3 workflow. The `/design` command creates design docs before implementation to align on approach, identify risks, and serve as handoff artifacts for the senior agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)